### PR TITLE
update GitHub User Guide v0.10.0

### DIFF
--- a/docs/04-UserManuals/github-user-guide-v0.10.0.md
+++ b/docs/04-UserManuals/github-user-guide-v0.10.0.md
@@ -102,7 +102,8 @@ See the pipeline finishes (progress 100%):
 
 2. Click 'Run Pipeline' and wait until it's finished.
 
-3. Click `View Dashboards` on the top left corner of `config-ui`
+3. Click `View Dashboards` on the top left corner of `config-ui`, the default username and password of Grafana are `admin`.
+Password: admin
 
 ![image](https://user-images.githubusercontent.com/61080/163666814-e48ac68d-a0cc-4413-bed7-ba123dd291c8.png)
 

--- a/docs/04-UserManuals/github-user-guide-v0.10.0.md
+++ b/docs/04-UserManuals/github-user-guide-v0.10.0.md
@@ -103,7 +103,6 @@ See the pipeline finishes (progress 100%):
 2. Click 'Run Pipeline' and wait until it's finished.
 
 3. Click `View Dashboards` on the top left corner of `config-ui`, the default username and password of Grafana are `admin`.
-Password: admin
 
 ![image](https://user-images.githubusercontent.com/61080/163666814-e48ac68d-a0cc-4413-bed7-ba123dd291c8.png)
 


### PR DESCRIPTION
The Grafana's default config is hidden in https://devlake.apache.org/docs/UserManuals/GRAFANA#logging-in. But the default username and password would be more appropriate to state here directly.