### PR TITLE
docs: add tag naming conventions rename local setup to docker compose setup

### DIFF
--- a/docs/DeveloperManuals/TagNamingConventions.md
+++ b/docs/DeveloperManuals/TagNamingConventions.md
@@ -1,0 +1,13 @@
+---
+title: "Tag Naming Conventions"
+description: >
+  Tag Naming Conventions
+sidebar_position: 6
+---
+
+Please refer to the rules when creating a new tag for Apache DevLake
+- alpha: internal testing/preview, i.e. v0.12.0-alpha1
+- beta: communtity/customer testing/preview, i.e. v0.12.0-beta1
+- rc: asf release candidate, i.e. v0.12.0-rc1
+
+

--- a/docs/Overview/Introduction.md
+++ b/docs/Overview/Introduction.md
@@ -16,7 +16,7 @@ Apache DevLake is designed for developer teams looking to make better sense of t
 
 ## How do I use DevLake?
 ### 1. Set up DevLake
-You can easily set up Apache DevLake by following our step-by step instructions for [local setup](../QuickStart/LocalSetup.md) or [Kubernetes setup](../QuickStart/KubernetesSetup.md).
+You can easily set up Apache DevLake by following our step-by step instructions for [Docker Compose setup](../QuickStart/DockerComposeSetup.md) or [Kubernetes setup](../QuickStart/KubernetesSetup.md).
 
 ### 2. Create a Blueprint
 The DevLake Configuration UI will guide you through the process (a Blueprint) to define the data connections, data scope, transformation and sync frequency of the data you wish to collect.

--- a/docs/QuickStart/DockerComposeSetup.md
+++ b/docs/QuickStart/DockerComposeSetup.md
@@ -1,7 +1,7 @@
 ---
-title: "Local Setup"
+title: "Install via Docker Compose"
 description: >
-  The steps to install DevLake locally
+  The steps to install DevLake via Docker Compose
 sidebar_position: 1
 ---
 

--- a/docs/QuickStart/KubernetesSetup.md
+++ b/docs/QuickStart/KubernetesSetup.md
@@ -1,7 +1,7 @@
 ---
-title: "Kubernetes Setup"
+title: "Install via Kubernetes"
 description: >
-  The steps to install Apache DevLake in Kubernetes
+  The steps to install Apache DevLake via Kubernetes
 sidebar_position: 2
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -172,7 +172,7 @@ const versions = require('./versions.json');
             items: [
               {
                 label: 'Quick Start',
-                to: 'docs/QuickStart/LocalSetup',
+                to: 'docs/QuickStart/DockerComposeSetup',
               },
               {
                 label: 'Data Models',


### PR DESCRIPTION
1. add tag naming conventions 
2. rename local setup to 'docker compose setup'

![image](https://user-images.githubusercontent.com/14050754/179746378-410cbb32-3965-4a60-9e60-50627b150aec.png)

![image](https://user-images.githubusercontent.com/14050754/179746455-b7d8c01f-ccbd-4fda-a079-ac3c6dafb0a7.png)

