### PR TITLE
docs: fix markdown format

### DIFF
--- a/docs/Metrics/CodingTime.md
+++ b/docs/Metrics/CodingTime.md
@@ -18,9 +18,11 @@ It is recommended that you keep every task on a workable and manageable scale fo
 
 ## How is it calculated?
 <b>Data Sources Required</b>
+
 This metric relies on PR/MRs collected from GitHub or GitLab.
 
 <b>Transformation Rules Required</b>
+
 N/A
 
 <b>SQL Queries</b>

--- a/docs/Metrics/CycleTime.md
+++ b/docs/Metrics/CycleTime.md
@@ -20,9 +20,11 @@ PR Cycle Time indicate the overall speed of the delivery progress in terms of PR
 You can define `deployment` based on your actual practice. For a full list of `deployment`'s definitions that DevLake support, please refer to [Deployment Frequency](/docs/Metrics/DeploymentFrequency.md).
 
 <b>Data Sources Required</b>
+
 This metric relies on PR/MRs collected from GitHub or GitLab.
 
 <b>Transformation Rules Required</b>
+
 N/A
 
 <b>SQL Queries</b>

--- a/docs/Metrics/DeployTime.md
+++ b/docs/Metrics/DeployTime.md
@@ -23,6 +23,7 @@ You can define `deployment` based on your actual practice. For a full list of `d
 This metric relies on PR/MRs collected from GitHub or GitLab.
 
 <b>Transformation Rules Required</b>
+
 N/A
 
 ## How to improve?

--- a/docs/Metrics/PRSize.md
+++ b/docs/Metrics/PRSize.md
@@ -20,9 +20,11 @@ Small PRs can reduce risks of introducing new bugs and increase code review qual
 This metric is calculated by counting the total number of code changes (in LOC) divided by the total number of PRs in the selected time range.
 
 <b>Data Sources Required</b>
+
 This metric relies on PR/MRs collected from GitHub or GitLab.
 
 <b>Transformation Rules Required</b>
+
 N/A
 
 <b>SQL Queries</b>

--- a/docs/Metrics/PickupTime.md
+++ b/docs/Metrics/PickupTime.md
@@ -18,9 +18,11 @@ PR Pickup Time shows how engaged your team is in collaborative work by identifyi
 
 ## How is it calculated?
 <b>Data Sources Required</b>
+
 This metric relies on PR/MRs collected from GitHub or GitLab.
 
 <b>Transformation Rules Required</b>
+
 N/A
 
 <b>SQL Queries</b>

--- a/docs/Metrics/ReviewDepth.md
+++ b/docs/Metrics/ReviewDepth.md
@@ -19,9 +19,11 @@ PR Review Depth (in Comments per RR) is related to the quality of code review, i
 This metric is calculated by counting the total number of PR comments divided by the total number of PRs in the selected time range.
 
 <b>Data Sources Required</b>
+
 This metric relies on PR/MRs collected from GitHub or GitLab.
 
 <b>Transformation Rules Required</b>
+
 N/A
 
 <b>SQL Queries</b>

--- a/docs/Metrics/ReviewTime.md
+++ b/docs/Metrics/ReviewTime.md
@@ -20,10 +20,13 @@ Code review should be conducted almost in real-time and usually take less than t
 
 ## How is it calculated?
 This metric is the time frame between when the first comment is added to a PR, to when the PR is merged.
+
 <b>Data Sources Required</b>
+
 This metric relies on PR/MRs collected from GitHub or GitLab.
 
 <b>Transformation Rules Required</b>
+
 N/A
 
 <b>SQL Queries</b>

--- a/docs/Metrics/TimeToMerge.md
+++ b/docs/Metrics/TimeToMerge.md
@@ -18,9 +18,11 @@ The delay of reviewing and waiting to review PRs has large impact on delivery sp
 
 ## How is it calculated?
 <b>Data Sources Required</b>
+
 This metric relies on PR/MRs collected from GitHub or GitLab.
 
 <b>Transformation Rules Required</b>
+
 N/A
 
 <b>SQL Queries</b>


### PR DESCRIPTION
Current Web Page Style:
<img width="972" alt="image" src="https://user-images.githubusercontent.com/5074190/186073525-343106e1-b9ad-4a95-b8cc-abd141143248.png">

Fixed Style:
<img width="611" alt="image" src="https://user-images.githubusercontent.com/5074190/186073580-111ea983-281f-4cd7-8564-4bc3497cffd4.png">


