### PR TITLE
docs: fix DORA metrics markdown format

### DIFF
--- a/docs/Metrics/CFR.md
+++ b/docs/Metrics/CFR.md
@@ -27,7 +27,7 @@ As you can see, there is not much distinction between performance benchmarks for
 | Medium performers| 16%-30%         |
 | Low performers   | 16%-30%         |
 
-<i>Source: 2021 Accelerate State of DevOps, Google</i>
+<p><i>Source: 2021 Accelerate State of DevOps, Google</i></p>
 
 <b>Data Sources Required</b>
 

--- a/docs/Metrics/DeploymentFrequency.md
+++ b/docs/Metrics/DeploymentFrequency.md
@@ -25,7 +25,7 @@ Deployment frequency is calculated based on the number of deployment days, not t
 | Medium performers| Once a month to once every six months|
 | Low performers   | Less than once every six months      |
 
-<i>Source: 2021 Accelerate State of DevOps, Google</i>
+<p><i>Source: 2021 Accelerate State of DevOps, Google</i></p>
 
 
 <b>Data Sources Required</b>

--- a/docs/Metrics/LeadTimeForChanges.md
+++ b/docs/Metrics/LeadTimeForChanges.md
@@ -36,7 +36,7 @@ Below are the benchmarks for different development teams:
 | Medium performers| Between one month and six months     |
 | Low performers   | More than six months                 |
 
-<i>Source: 2021 Accelerate State of DevOps, Google</i>
+<p><i>Source: 2021 Accelerate State of DevOps, Google</i></p>
 
 <b>Data Sources Required</b>
 

--- a/docs/Metrics/MTTR.md
+++ b/docs/Metrics/MTTR.md
@@ -29,7 +29,7 @@ Below are the benchmarks for different development teams:
 | Medium performers| Between one day and one week         |
 | Low performers   | More than six months                 |
 
-<i>Source: 2021 Accelerate State of DevOps, Google</i>
+<p><i>Source: 2021 Accelerate State of DevOps, Google</i></p>
 
 <b>Data Sources Required</b>
 

--- a/versioned_docs/version-v0.13/Metrics/CFR.md
+++ b/versioned_docs/version-v0.13/Metrics/CFR.md
@@ -27,7 +27,7 @@ As you can see, there is not much distinction between performance benchmarks for
 | Medium performers| 16%-30%         |
 | Low performers   | 16%-30%         |
 
-<i>Source: 2021 Accelerate State of DevOps, Google</i>
+<p><i>Source: 2021 Accelerate State of DevOps, Google</i></p>
 
 <b>Data Sources Required</b>
 

--- a/versioned_docs/version-v0.13/Metrics/DeploymentFrequency.md
+++ b/versioned_docs/version-v0.13/Metrics/DeploymentFrequency.md
@@ -25,7 +25,7 @@ Deployment frequency is calculated based on the number of deployment days, not t
 | Medium performers| Once a month to once every six months|
 | Low performers   | Less than once every six months      |
 
-<i>Source: 2021 Accelerate State of DevOps, Google</i>
+<p><i>Source: 2021 Accelerate State of DevOps, Google</i></p>
 
 
 <b>Data Sources Required</b>

--- a/versioned_docs/version-v0.13/Metrics/LeadTimeForChanges.md
+++ b/versioned_docs/version-v0.13/Metrics/LeadTimeForChanges.md
@@ -36,7 +36,7 @@ Below are the benchmarks for different development teams:
 | Medium performers| Between one month and six months     |
 | Low performers   | More than six months                 |
 
-<i>Source: 2021 Accelerate State of DevOps, Google</i>
+<p><i>Source: 2021 Accelerate State of DevOps, Google</i></p>
 
 <b>Data Sources Required</b>
 

--- a/versioned_docs/version-v0.13/Metrics/MTTR.md
+++ b/versioned_docs/version-v0.13/Metrics/MTTR.md
@@ -29,7 +29,7 @@ Below are the benchmarks for different development teams:
 | Medium performers| Between one day and one week         |
 | Low performers   | More than six months                 |
 
-<i>Source: 2021 Accelerate State of DevOps, Google</i>
+<p><i>Source: 2021 Accelerate State of DevOps, Google</i></p>
 
 <b>Data Sources Required</b>
 


### PR DESCRIPTION
fix DORA metrics markdown format

current:
<img width="991" alt="image" src="https://user-images.githubusercontent.com/5074190/187894330-a6ca467f-03fc-4f82-8ac9-a89761b54804.png">

fixed:
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/5074190/187894448-070426b4-4c58-40dd-8127-25c9d09bbdbb.png">
