### PR TITLE
fix: `prefered`(typo) --> `preferred`

### DIFF
--- a/docs/UserManuals/ConfigUI/AdvancedMode.md
+++ b/docs/UserManuals/ConfigUI/AdvancedMode.md
@@ -30,7 +30,7 @@ Advanced mode gives utmost flexibility to users by exposing the JSON API.
 
 ![image](/img/AdvancedMode/AdvancedMode3.png)
 
-4. You can choose how often you would like to sync your data in this step by selecting a sync frequency option or enter a cron code to specify your prefered schedule. After setting up the Blueprint, you will be prompted to the Blueprint's activity detail page, where you can track the progress of the current run and wait for it to finish before the dashboards become available. You can also view all historical runs of previously created Blueprints from the list on the Blueprint page.
+4. You can choose how often you would like to sync your data in this step by selecting a sync frequency option or enter a cron code to specify your preferred schedule. After setting up the Blueprint, you will be prompted to the Blueprint's activity detail page, where you can track the progress of the current run and wait for it to finish before the dashboards become available. You can also view all historical runs of previously created Blueprints from the list on the Blueprint page.
 
 ## Examples
 


### PR DESCRIPTION
typo `prefered` corrected to `preferred`