### PR TITLE
Fixes #2937, broken link to sample k8s deploy file

### DIFF
--- a/docs/GettingStarted/KubernetesSetup.md
+++ b/docs/GettingStarted/KubernetesSetup.md
@@ -5,13 +5,13 @@ description: >
 sidebar_position: 2
 ---
 
-We provide a sample [k8s-deploy.yaml](https://github.com/apache/incubator-devlake/blob/main/k8s-deploy.yaml) to help deploy DevLake to Kubernetes
+We provide a sample [k8s-deploy.yaml](https://github.com/apache/incubator-devlake/blob/main/deployment/k8s/k8s-deploy.yaml) to help deploy DevLake to Kubernetes
 
-[k8s-deploy.yaml](https://github.com/apache/incubator-devlake/blob/main/k8s-deploy.yaml) will create a namespace `devlake` on your k8s cluster, and use `nodePort 30004` for `config-ui`,  `nodePort 30002` for `grafana` dashboards. If you would like to use a specific version of Apache DevLake, please update the image tag of `grafana`, `devlake` and `config-ui` deployments.
+[k8s-deploy.yaml](https://github.com/apache/incubator-devlake/blob/main/deployment/k8s/k8s-deploy.yaml) will create a namespace `devlake` on your k8s cluster, and use `nodePort 30004` for `config-ui`,  `nodePort 30002` for `grafana` dashboards. If you would like to use a specific version of Apache DevLake, please update the image tag of `grafana`, `devlake` and `config-ui` deployments.
 
 ## Step-by-step guide
 
-1. Download [k8s-deploy.yaml](https://github.com/apache/incubator-devlake/blob/main/k8s-deploy.yaml)
+1. Download [k8s-deploy.yaml](https://github.com/apache/incubator-devlake/blob/main/deployment/k8s/k8s-deploy.yaml)
 2. Customize the settings (`devlake-config` config map):
    - Settings shared between `grafana` and `mysql`
      * `MYSQL_ROOT_PASSWORD`: set root password for `mysql`


### PR DESCRIPTION
Fixes the broken link to sample k8s-deploy file. Issue #2937 https://github.com/apache/incubator-devlake/issues/2937