### PR TITLE
fix: Join Community Responsiveness Fixed

### DIFF
--- a/src/components/Sections/JoinCommunity.tsx
+++ b/src/components/Sections/JoinCommunity.tsx
@@ -5,9 +5,9 @@ import Join from "@site/static/img/Homepage/Join.png";
 import { InlineLink } from "./Components";
 
 export function JoinCommunity() {
-  return (<div className="flex justify-between sm:flex-col-reverse
-    my-[72px] rounded-[20px] bg-primary-200 px-6 py-[36px] font-inter
-    sm:w-[87vw] sm:my-6 sm:p-4 mobile:my-10 mobile:p-3">
+  return (<div className="flex align-self-center justify-between xl:relative right-2
+    my-[72px] rounded-[20px] bg-primary-200 px-5 py-[36px] font-inter xl:mx-auto xl:w-[72vw] xl:max-w-[1300px]
+    sm:w-[87vw] sm:my-6 sm:p-4 mobile:my-4 mobile:p-3">
     <div className="w-[600px] pr-3 sm:pr-[0] sm:w-auto">
       <div className="text-heading1 mb-3 text-primary-800 font-semibold
         sm:text-heading2">Join the Community</div>


### PR DESCRIPTION
Closes #226 
## Before Fix : 
![joinCommunityError](https://user-images.githubusercontent.com/72302948/193762372-97f7105a-ea51-4de0-80de-40e63082b927.gif)

## After Fix : 
![joinCommunitySolution](https://user-images.githubusercontent.com/72302948/193762420-ed56bc0d-8c27-471c-9f47-16b89048ea38.gif)

## Note : 
In the second part of the issue, the box is not misaligned, actually the image has some padding that makes it look like that it is misaligned. Kindly reference the image below : 
<img width="1750" alt="image" src="https://user-images.githubusercontent.com/72302948/193762942-e238d501-896f-4de6-864d-153faf00ed66.png">
