### PR TITLE
docs: fix grafana doc link

### DIFF
--- a/docs/UserManuals/DORA.md
+++ b/docs/UserManuals/DORA.md
@@ -172,7 +172,7 @@ For a breakdown of each metric's SQL query, please refer to the corresponding me
   - [Median Time to Restore Service](https://devlake.apache.org/docs/Metrics/MTTR)
   - [Change Failure Rate](https://devlake.apache.org/docs/Metrics/CFR)
 
-If you aren't familiar with Grafana, please refer to our [Grafana doc], or jump into Slack for help. (./Dashboards/GrafanaUserGuide.md)
+If you aren't familiar with Grafana, please refer to our [Grafana doc](./Dashboards/GrafanaUserGuide.md), or jump into Slack for help.
 
 <br/>
 


### PR DESCRIPTION
This is a one-line PR, fixing the grafana doc link in DORA doc.

<img width="1225" alt="Screen Shot 2022-10-16 at 7 14 34 PM" src="https://user-images.githubusercontent.com/2908155/196074731-7708898f-284d-49b3-868a-5e049ba1f84a.png">
