### PR TITLE
Put webhook on internet

### DIFF
--- a/docs/Plugins/webhook.md
+++ b/docs/Plugins/webhook.md
@@ -20,7 +20,7 @@ To add a new webhook, go to the "Data Connections" page in config-ui and select 
 
 We recommend that you give your webhook connection a unique name so that you can identify and manage where you have used it later.
 
-After clicking on the "Generate POST URL" button, you will find four webhook URLs. Copy the ones that suit your usage into your CI or issue tracking systems. You can always come back to the webhook page to copy the URLs later on.
+After clicking on the "Generate POST URL" button, you will find several webhook URLs. You can then post to these URLs from your CI/CD tool or issue tracking system to push data directly to DevLake. You can always come back to the webhook page to access the URLs later.
 
 ![](https://i.imgur.com/jBMQnjt.png)
 

--- a/docs/Plugins/webhook.md
+++ b/docs/Plugins/webhook.md
@@ -24,6 +24,16 @@ After clicking on the "Generate POST URL" button, you will find several webhook 
 
 ![](https://i.imgur.com/jBMQnjt.png)
 
+### Put webhook on the internet
+
+For the new webhook to work, it needs to be accessible from the DevOps tools from which you would like to push data to DevLake. If DevLake is deployed in your private network and your DevOps tool (e.g. CircleCI) is a cloud service that lives outside of your private network, then you need to make DevLake's webhook accessible to the outside cloud service.
+
+There're many tools for this:
+
+  - For testing and quick setup, [ngrok](https://ngrok.com/) is a useful utility that provides a publicly accessible web URL to any locally hosted application. You can put DevLake's webhook on the internet within 5 mins by following ngrok's [Getting Started](https://ngrok.com/docs/getting-started) guide. Note that, when posting to webhook, you may need to replace the `localhost` part in the webhook URL with the forwarding URL that ngrok provides.
+  - If you prefer DIY, please checkout open-source reverse proxies like [fatedier/frp](https://github.com/fatedier/frp) or go for the classic [nginx](https://www.nginx.com/).
+
+
 ## Register a deployment
 
 You can copy the generated deployment curl commands to your CI/CD script to post deployments to Apache DevLake. Below is the detailed payload schema:

--- a/docs/UserManuals/ConfigUI/webhook.md
+++ b/docs/UserManuals/ConfigUI/webhook.md
@@ -18,13 +18,3 @@ After clicking on "Generate POST URL", you will find four webhook URLs. Copy the
 ![image](https://user-images.githubusercontent.com/3294100/191400110-327c153f-b236-47e3-88cc-85bf8fcae310.png)
 
 For more usage: [plugins/webhook](/Plugins/webhook.md).
-
-
-### Webhook Accessibility
-
-In real-world scenarios, most likely, you would like to call the webhook API from another machine inside some CI/CD scripts. The CI/CD Machine may be located in the same Internal Network or provided by a Cloud Service. 
-
-In any case, the only rule is to make sure the CI/CD Machine could reach the config-ui instance.
-
-  - Access the config-ui via IP Address or Domain Name that is accessible from the CI/CD Machine, since the Webhook FQDN is generated based on the Browser URL. In other words, `localhost` and `127.0.0.1` might not work.
-  - If you set up Apache DevLake as [Internal Deployment](../Authentication#internal-deployment-recommended) and the CI/CD Machine belongs to a Cloud Service Provider, you may have to switch to `Internet Deployment` or employ reverse-proxy software like [fatedier/frp](https://github.com/fatedier/frp).


### PR DESCRIPTION
Summary for this PR:

1. Move webhook accessibility section from Config UI/webhook to Plugins/webhook
2. Provide an easy way for user to host webhook on the internet through ngrok (https://ngrok.com/)
3. Fix some minor issues in Plugins/webhook.md