### PR TITLE
docs: removed unneeded permissions for Github

### DIFF
--- a/docs/UserManuals/ConfigUI/GitHub.md
+++ b/docs/UserManuals/ConfigUI/GitHub.md
@@ -16,11 +16,9 @@ This should be a valid REST API endpoint, eg. `https://api.github.com/`. The url
 
 #### Auth Token(s)
 GitHub personal access tokens are required to add a connection.
-- Learn about [how to create a GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). The following permissions are required for private repositories:
+- Learn about [how to create a GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). The following permissions are required for `Apache DevLake` to collect data from private repositories:
   - `repo:status`
   - `repo_deployment`
-  - `public_repo`
-  - `repo:invite`
   - `read:user`
   - `read:org`
 - The data collection speed is relatively slow for GitHub since they have a **rate limit of [5,000 requests](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting) per hour** (15,000 requests/hour if you pay for GitHub enterprise). You can accelerate the process by configuring _multiple_ personal access tokens. Please note that multiple tokens should be created by different GitHub accounts. Tokens belonging to the same GitHub account share the rate limit.


### PR DESCRIPTION
Closes apache/incubator-devlake#2942