### PR TITLE
fix : typo "MadPorts" --> "MacPorts" 

### DIFF
--- a/docs/Plugins/refdiff.md
+++ b/docs/Plugins/refdiff.md
@@ -137,7 +137,7 @@ No package 'libgit2' found pkg-config: exit status 1
 
 ### MacOS
 
-NOTE：Do **NOT** install libgit2 via `MadPorts` or `homebrew`, install from source instead.
+NOTE：Do **NOT** install libgit2 via `MacPorts` or `homebrew`, install from source instead.
 ```
 brew install cmake
 git clone https://github.com/libgit2/libgit2.git


### PR DESCRIPTION
# Summary

Fixed a typo i.e. "MadPorts" to "MacPorts" to avoid confusion via installing the Rediff plugin via Source instead oh MacPorts or Homebrew for macOS due to incompatibility of libgit2 version

### Does this close any open issues?
Extension of #163 and #165
