### PR TITLE
Added godoc reference

### DIFF
--- a/docs/DeveloperManuals/DeveloperSetup.md
+++ b/docs/DeveloperManuals/DeveloperSetup.md
@@ -120,3 +120,7 @@ For provisioning, customizing, and creating dashboards, please refer to our [Gra
     - Compile specific plugins: `PLUGIN=<PLUGIN_NAME> make build-plugin`
     - Compile server: `make build`
     - Compile worker: `make build-worker`
+
+## References
+
+To dig deeper into developing and utilizing our built-in functions and have a better developer experience, feel free to dive into our [godoc](https://pkg.go.dev/github.com/apache/incubator-devlake) reference.


### PR DESCRIPTION
# Summary
Added godoc reference under `References` section at [Developer Setup](https://devlake.apache.org/docs/next/DeveloperManuals/DeveloperSetup/)  for better dev experience and better understanding for contributors

### Does this close any open issues?
Closes #54 