### PR TITLE
docs: how to collect data from self-signed gitlab

### DIFF
--- a/docs/UserManuals/ConfigUI/GitLab.md
+++ b/docs/UserManuals/ConfigUI/GitLab.md
@@ -54,15 +54,17 @@ You can choose how often you would like to sync your data in this step by select
 ## FAQ
 
 ### How to collect data from Gitlab server with Self-Signed Certificate
-There are two symptoms would exhibit when trying to collect data from a private Gitlab server with a Self-Signed certificate:
 
-1. "Test Connection" report error, this can be solved by setting the environment variable `IN_SECURE_SKIP_VERIFY=true` for the `devlake` container
-2. "GitExtractor" fails to clone the repository due to certificate verification, sadly, both `gogit` and `git2go` that we are using don't seem to support insecure HTTPS at all.
+There might be two problems when trying to collect data from a private GitLab server with a self-signed certificate:
+
+1. "Test Connection" error. This can be solved by setting the environment variable `IN_SECURE_SKIP_VERIFY=true` for the `devlake` container
+2. "GitExtractor" fails to clone the repository due to certificate verification, sadly, neither gogit nor git2go we are using supports insecure HTTPS.
 
 A better approach would be adding your root CA to the `devlake` container:
 
 1. Mount your `rootCA.crt` into the `devlake` container
 2. Add a `command` node to install the mounted certificate
+
 ```
   devlake:
     image: apache/devlake:v...
@@ -73,4 +75,3 @@ A better approach would be adding your root CA to the `devlake` container:
     command: [ "sh", "-c", "update-ca-certificates; lake" ]
     ...
 ```
-

--- a/docs/UserManuals/ConfigUI/GitLab.md
+++ b/docs/UserManuals/ConfigUI/GitLab.md
@@ -49,3 +49,28 @@ There are no transformation rules for GitLab repos.
 
 ### Step 4 - Setting Sync Frequency
 You can choose how often you would like to sync your data in this step by selecting a sync frequency option or enter a cron code to specify your prefered schedule.
+
+
+## FAQ
+
+### How to collect data from Gitlab server with Self-Signed Certificate
+There are two symptoms would exhibit when trying to collect data from a private Gitlab server with a Self-Signed certificate:
+
+1. "Test Connection" report error, this can be solved by setting the environment variable `IN_SECURE_SKIP_VERIFY=true` for the `devlake` container
+2. "GitExtractor" fails to clone the repository due to certificate verification, sadly, both `gogit` and `git2go` that we are using don't seem to support insecure HTTPS at all.
+
+A better approach would be adding your root CA to the `devlake` container:
+
+1. Mount your `rootCA.crt` into the `devlake` container
+2. Add a `command` node to install the mounted certificate
+```
+  devlake:
+    image: apache/devlake:v...
+    ...
+    volumes:
+      ...
+      - /path/to/your/rootCA.crt:/usr/local/share/ca-certificates/rootCA.crt
+    command: [ "sh", "-c", "update-ca-certificates; lake" ]
+    ...
+```
+


### PR DESCRIPTION
# Summary

Some users may use self-signed certificate for their gitlab server. however, the gitextractor would fail in this case. 

This PR adds a section to describe the solution for the case

### Does this close any open issues?
Closes apache/incubator-devlake#3226


