### PR TITLE
docs: add missing configuration to user manuals

### DIFF
--- a/docs/UserManuals/ConfigUI/GitHub.md
+++ b/docs/UserManuals/ConfigUI/GitHub.md
@@ -82,6 +82,19 @@ Each GitHub repo has at most ONE set of transformation rules.
 
 - Type/Incident: Same as "Type/Requirement", with `type` setting to "INCIDENT".
 
+#### CI/CD
+![image](https://user-images.githubusercontent.com/14050754/208100921-abc28c75-6001-493d-b307-3fd9879db552.png)
+
+This set of configurations is used for calculating [DORA metrics](../DORA.md).
+
+If you're using GitHub Action to conduct `deployments`, please select "Detect Deployment from Jobs in GitHub Action", and input the RegEx in the following fields:
+- Deployment: A GitHub Action job with a name that matches the given regEx will be considered as a deployment.
+- Production: A GitHub Action job with a name that matches the given regEx will be considered a job in the production environment.
+
+By the above two fields, DevLake can identify a production deployment among massive CI jobs.
+
+You can also select "Not using Jobs in GitHub Action as Deployments" if you're not using GitHub action to conduct deployments.
+
 #### Code Review
 
 - Type: The `type` of pull requests will be parsed from PR labels by given regular expression. For example:

--- a/docs/UserManuals/ConfigUI/GitLab.md
+++ b/docs/UserManuals/ConfigUI/GitLab.md
@@ -34,7 +34,7 @@ Click `Test Connection`, if the connection is successful, click `Save Connection
 #### Projects
 Choose the Gitlab projects to collect. Limited by GitLab API, You need to type more than 2 characters to search.
 
-* If you want to collect public repos in GitLab, please uncheck "Only search my repositories" to find all repos.
+* If you want to collect public repositories in GitLab, please uncheck "Only search my repositories" to search all repositories.
 
 #### Data Entities
 Usually, you don't have to modify this part. However, if you don't want to collect certain GitLab entities, you can unselect some entities to accerlerate the collection speed.
@@ -45,7 +45,17 @@ Usually, you don't have to modify this part. However, if you don't want to colle
 - Cross Domain: GitLab accounts, etc.
 
 ### Step 3 - Adding Transformation Rules (Optional)
-There are no transformation rules for GitLab repos.
+
+#### CI/CD
+This set of configurations is used for calculating [DORA metrics](../DORA.md).
+
+If you're using GitLab CI to conduct `deployments`, please select "Detect Deployment from Jobs in GitLab CI", and input the RegEx in the following fields:
+- Deployment: A GitLab CI job with a name that matches the given regEx will be considered as a deployment.
+- Production: A GitLab CI job with a name that matches the given regEx will be considered a job in the production environment.
+
+By the above two fields, DevLake can identify a production deployment among massive CI jobs.
+
+You can also select "Not using Jobs in GitLab CI as Deployments" if you're not using GitLab CI to conduct deployments.
 
 ### Step 4 - Setting Sync Frequency
 You can choose how often you would like to sync your data in this step by selecting a sync frequency option or enter a cron code to specify your prefered schedule.

--- a/docs/UserManuals/ConfigUI/Jenkins.md
+++ b/docs/UserManuals/ConfigUI/Jenkins.md
@@ -29,7 +29,7 @@ Click `Test Connection`, if the connection is successful, click `Save Connection
 
 #### Jobs
 
-Choose the Jenkins jobs to collect.
+Choose the Jenkins jobs. All `Jenkins builds` under these jobs will be collected.
 
 #### Data Entities
 
@@ -38,7 +38,15 @@ Jenkins only supports `CI/CD` domain entities, transformed from Jenkins builds a
 - CI/CD: Jenkins builds, stages, etc.
 
 ### Step 3 - Adding Transformation Rules (Optional)
-There are no transformation rules for Jenkins.
+This set of configurations is used for calculating [DORA metrics](../DORA.md).
+
+If you're using Jenkins builds to conduct `deployments`, please select "Detect Deployment from Jenkins Builds", and input the RegEx in the following fields:
+- Deployment: A Jenkins build with a name that matches the given regEx will be considered as a deployment.
+- Production: A Jenkins build with a name that matches the given regEx will be considered a build in the production environment.
+
+By the above two fields, DevLake can identify a production deployment among massive CI jobs.
+
+You can also select "Not using Jenkins builds as Deployments" if you're not using Jenkins to conduct deployments.
 
 ### Step 4 - Setting Sync Frequency
 You can choose how often you would like to sync your data in this step by selecting a sync frequency option or enter a cron code to specify your prefered schedule.

--- a/docs/UserManuals/ConfigUI/Tapd.md
+++ b/docs/UserManuals/ConfigUI/Tapd.md
@@ -1,5 +1,5 @@
 ---
-title: "Configuring Tapd"
+title: "Configuring Tapd(WIP)"
 sidebar_position: 6
 description: Config UI instruction for Tapd
 ---
@@ -24,7 +24,7 @@ Input the username and password of your Tapd account, you can follow the steps a
 If you are behind a corporate firewall or VPN you may need to utilize a proxy server. Enter a valid proxy server address on your network, e.g. `http://your-proxy-server.com:1080`
 
 #### Ralte Limit (Optional)
-For tapd, we suggest you to set rate limit to 3500
+For TAPD, we suggest you setting the rate limit to 3500
 
 #### Test and Save Connection
 Click `Test Connection`, if the connection is successful, click `Save Connection` to add the connection.

--- a/versioned_docs/version-v0.14/UserManuals/ConfigUI/GitHub.md
+++ b/versioned_docs/version-v0.14/UserManuals/ConfigUI/GitHub.md
@@ -69,11 +69,25 @@ Each GitHub repo has at most ONE set of transformation rules.
 
 - Priority: Same as "Severity".
 
-- Type/Requirement: The `type` of issues with labels that match given regular expression will be set to "REQUIREMENT". Unlike "PR.type", submatch does nothing, because for issue management analysis, users tend to focus on 3 kinds of types (Requirement/Bug/Incident), however, the concrete naming varies from repo to repo, time to time, so we decided to standardize them to help analysts metrics.
+- Type/Requirement: The `type` of issues with labels that match the given regular expression will be set to "REQUIREMENT". Unlike "PR.type", submatch does nothing, because for issue management analysis, users tend to focus on 3 kinds of types (Requirement/Bug/Incident), however, the concrete naming varies from repo to repo, from time to time, so we decided to standardize them to help analysts metrics.
 
-- Type/Bug: Same as "Type/Requirement", with `type` setting to "BUG".
+- Type/Bug: Same as "Type/Requirement", with `type` set to "BUG".
 
-- Type/Incident: Same as "Type/Requirement", with `type` setting to "INCIDENT".
+- Type/Incident: Same as "Type/Requirement", with `type` set to "INCIDENT".
+
+#### CI/CD
+![image](https://user-images.githubusercontent.com/14050754/208100921-abc28c75-6001-493d-b307-3fd9879db552.png)
+
+This set of configurations is used for calculating [DORA metrics](../DORA.md).
+
+If you're using GitHub Action to conduct `deployments`, please select "Detect Deployment from Jobs in GitHub Action", and input the RegEx in the following fields:
+- Deployment: A GitHub Action job with a name that matches the given regEx will be considered as a deployment.
+- Production: A GitHub Action job with a name that matches the given regEx will be considered a job in the production environment.
+
+By the above two fields, DevLake can identify a production deployment among massive CI jobs.
+
+You can also select "Not using Jobs in GitHub Action as Deployments" if you're not using GitHub action for deployments.
+
 
 #### Code Review
 
@@ -82,6 +96,7 @@ Each GitHub repo has at most ONE set of transformation rules.
    - when your labels for PR types are like 'feature-development', 'bug-fixing' and 'docs', please input '(feature-development|bug-fixing|docs)$'
 
 - Component: The `component` of pull requests will be parsed from PR labels by given regular expression.
+
 
 #### Additional Settings (Optional)
 

--- a/versioned_docs/version-v0.14/UserManuals/ConfigUI/GitLab.md
+++ b/versioned_docs/version-v0.14/UserManuals/ConfigUI/GitLab.md
@@ -30,14 +30,12 @@ Click `Test Connection`, if the connection is successful, click `Save Connection
 
 ### Step 2 - Setting Data Scope
 
+![image](https://user-images.githubusercontent.com/3294100/199533780-f506b308-6808-499c-90db-b39fcda27888.png)
+
 #### Projects
-Enter the GitLab repos to collect. How to get `GitLab` repos?
-- Visit the repository page on GitLab
-- Find the project id below the title
+Choose the Gitlab projects to collect. Limited by GitLab API, You need to type more than 2 characters to search.
 
-![Get GitLab projects](https://user-images.githubusercontent.com/3789273/128568416-a47b2763-51d8-4a6a-8a8b-396512bffb03.png)
-
-If you want to collect more than 1 repo, please separate repos with comma. For example, "apache/incubator-devlake,apache/incubator-devlake-website".
+* If you want to collect public repositories in GitLab, please uncheck "Only search my repositories" to search all repositories.
 
 #### Data Entities
 Usually, you don't have to modify this part. However, if you don't want to collect certain GitLab entities, you can unselect some entities to accerlerate the collection speed.
@@ -47,7 +45,17 @@ Usually, you don't have to modify this part. However, if you don't want to colle
 - Cross Domain: GitLab accounts, etc.
 
 ### Step 3 - Adding Transformation Rules (Optional)
-There are no transformation rules for GitLab repos.
+
+#### CI/CD
+This set of configurations is used for calculating [DORA metrics](../DORA.md).
+
+If you're using GitLab CI to conduct `deployments`, please select "Detect Deployment from Jobs in GitLab CI", and input the RegEx in the following fields:
+- Deployment: A GitLab CI job with a name that matches the given regEx will be considered as a deployment.
+- Production: A GitLab CI job with a name that matches the given regEx will be considered a job in the production environment.
+
+By the above two fields, DevLake can identify a production deployment among massive CI jobs.
+
+You can also select "Not using Jobs in GitLab CI as Deployments" if you're not using GitLab CI to conduct deployments.
 
 ### Step 4 - Setting Sync Frequency
 You can choose how often you would like to sync your data in this step by selecting a sync frequency option or enter a cron code to specify your prefered schedule.

--- a/versioned_docs/version-v0.14/UserManuals/ConfigUI/Jenkins.md
+++ b/versioned_docs/version-v0.14/UserManuals/ConfigUI/Jenkins.md
@@ -27,7 +27,15 @@ Click `Test Connection`, if the connection is successful, click `Save Connection
 There is no data cope setting for Jenkins.
 
 ### Step 3 - Adding Transformation Rules (Optional)
-There are no transformation rules for Jenkins.
+This set of configurations is used for calculating [DORA metrics](../DORA.md).
+
+If you're using Jenkins builds to conduct `deployments`, please select "Detect Deployment from Jenkins Builds", and input the RegEx in the following fields:
+- Deployment: A Jenkins build with a name that matches the given regEx will be considered as a deployment.
+- Production: A Jenkins build with a name that matches the given regEx will be considered a build in the production environment.
+
+By the above two fields, DevLake can identify a production deployment among massive CI jobs.
+
+You can also select "Not using Jenkins builds as Deployments" if you're not using Jenkins to conduct deployments.
 
 ### Step 4 - Setting Sync Frequency
 You can choose how often you would like to sync your data in this step by selecting a sync frequency option or enter a cron code to specify your prefered schedule.

--- a/versioned_docs/version-v0.14/UserManuals/ConfigUI/Tapd.md
+++ b/versioned_docs/version-v0.14/UserManuals/ConfigUI/Tapd.md
@@ -1,5 +1,5 @@
 ---
-title: "Configuring Tapd"
+title: "Configuring Tapd(WIP)"
 sidebar_position: 6
 description: Config UI instruction for Tapd
 ---


### PR DESCRIPTION
### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have `npm run build` and `npm run serve` locally before submitting this PR
- [x] I have read through the [Contributing](https://devlake.apache.org/community/) Documentation

# Summary
1. docs: add missing CICD configuration to next and v0.14 user manuals: GitHub, GitLab, Jenkins
2. fix the bug of the GitLab manual
3. update wordings in TAPD 

### Does this close any open issues?
Closes https://github.com/apache/incubator-devlake/issues/3855

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
