### PR TITLE
[FIX] Updated Node version requirements for dev-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,18 @@ This project keeps all sources used for building up DevLake's official website w
 
 ## Prerequisite
 
-
-Please also make sure your node version is 10+, version lower than 10.x is not supported yet.
-
+Please also make sure your node version is 16.14+, version lower than 16.14.x is not supported yet.
+ 
 ## Installation
 
 1. Run `yarn install` or `yarn` in the root directory to install the dependencies.
 2. Run `yarn start` in the root directory to start a local server, you will see the website in http://localhost:3000.
 
-If you have higher version of node installed, you may consider `nvm` to allow different versions of `node` coexisting on your machine.
+Make sure you have the `node` version `>=16.14`. If you have a lower version of node installed, you may consider setting up `nvm` to allow different versions of `node` coexisting on your machine.
 
-1. Follow the [instructions](http://nvm.sh) to install nvm
-2. Run `nvm install v10.23.1` to install node v10
-3. Run `nvm use v10.23.1` to switch the working environment to node v10
+1. Follow the [instructions](http://nvm.sh) to install and setup nvm
+2. Run `nvm install v16.14` to install node v16.14
+3. Run `nvm use v16.14` to switch the working environment to node v16
 
 ## How to send a PR
 


### PR DESCRIPTION
# Summary
While setting up this **docs repository** for development, node version `10.23.1` isn't supported by docusaurus as shown in the below screenshot, hence updated the version to `16.14` in the dev-setup docs to avoid confusion!

### Screenshots
<img width="1076" alt="Screenshot 2022-12-24 at 10 05 37 AM" src="https://user-images.githubusercontent.com/73993394/209421773-77fee449-1782-43d5-94b9-549d515a1dea.png">
