### PR TITLE
fix: fix a typo in the sample request of bitbucket plugin

### DIFF
--- a/docs/Plugins/bitbucket.md
+++ b/docs/Plugins/bitbucket.md
@@ -37,7 +37,7 @@ curl --location --request POST 'http://localhost:8080/plugins/bitbucket/connecti
 curl --location --request POST 'http://localhost:8080/blueprints' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-    "enabled": true,
+    "enable": true,
     "mode": "NORMAL",
     "name": "My Bitbucket Blueprint",
     "cronConfig": "<cron string of your choice>",

--- a/versioned_docs/version-v0.14/Plugins/bitbucket.md
+++ b/versioned_docs/version-v0.14/Plugins/bitbucket.md
@@ -37,7 +37,7 @@ curl --location --request POST 'http://localhost:8080/plugins/bitbucket/connecti
 curl --location --request POST 'http://localhost:8080/blueprints' \
 --header 'Content-Type: application/json' \
 --data-raw '{
-    "enabled": true,
+    "enable": true,
     "mode": "NORMAL",
     "name": "My Bitbucket Blueprint",
     "cronConfig": "<cron string of your choice>",


### PR DESCRIPTION
# Summary

fix a typo in the sample request of the bitbucket plugin. `enabled` -> `enable`