### PR TITLE
Added caution messages and recommending helm installation over k8s

### DIFF
--- a/docs/GettingStarted/HelmSetup.md
+++ b/docs/GettingStarted/HelmSetup.md
@@ -2,7 +2,7 @@
 title: "Install via Helm"
 description: >
   The steps to install Apache DevLake via Helm for Kubernetes
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 ## Prerequisites

--- a/docs/GettingStarted/KubernetesSetup.md
+++ b/docs/GettingStarted/KubernetesSetup.md
@@ -2,8 +2,14 @@
 title: "Install via Kubernetes"
 description: >
   The steps to install Apache DevLake via Kubernetes
-sidebar_position: 2
+sidebar_position: 3
 ---
+
+:::caution
+
+We highly recommend the [helm approach](./HelmSetup.md), this page is for Advanced Installation only
+
+:::
 
 We provide a sample [k8s-deploy.yaml](https://github.com/apache/incubator-devlake/blob/main/deployment/k8s/k8s-deploy.yaml) to help deploy DevLake to Kubernetes
 

--- a/versioned_docs/version-v0.12/QuickStart/HelmSetup.md
+++ b/versioned_docs/version-v0.12/QuickStart/HelmSetup.md
@@ -2,7 +2,7 @@
 title: "Install via Helm"
 description: >
   The steps to install Apache DevLake via Helm for Kubernetes
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 ## Prerequisites

--- a/versioned_docs/version-v0.12/QuickStart/KubernetesSetup.md
+++ b/versioned_docs/version-v0.12/QuickStart/KubernetesSetup.md
@@ -2,8 +2,14 @@
 title: "Install via Kubernetes"
 description: >
   The steps to install Apache DevLake via Kubernetes
-sidebar_position: 2
+sidebar_position: 3
 ---
+
+:::caution
+
+We highly recommend the [helm approach](./HelmSetup.md), this page is for Advanced Installation only
+
+:::
 
 We provide a sample [k8s-deploy.yaml](https://github.com/apache/incubator-devlake/blob/main/k8s-deploy.yaml) to help deploy DevLake to Kubernetes
 

--- a/versioned_docs/version-v0.13/GettingStarted/HelmSetup.md
+++ b/versioned_docs/version-v0.13/GettingStarted/HelmSetup.md
@@ -2,7 +2,7 @@
 title: "Install via Helm"
 description: >
   The steps to install Apache DevLake via Helm for Kubernetes
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 ## Prerequisites

--- a/versioned_docs/version-v0.13/GettingStarted/KubernetesSetup.md
+++ b/versioned_docs/version-v0.13/GettingStarted/KubernetesSetup.md
@@ -2,8 +2,14 @@
 title: "Install via Kubernetes"
 description: >
   The steps to install Apache DevLake via Kubernetes
-sidebar_position: 2
+sidebar_position: 3
 ---
+
+:::caution
+
+We highly recommend the [helm approach](./HelmSetup.md), this page is for Advanced Installation only
+
+:::
 
 We provide a sample [k8s-deploy.yaml](https://github.com/apache/incubator-devlake/blob/main/k8s-deploy.yaml) to help deploy DevLake to Kubernetes
 

--- a/versioned_docs/version-v0.14/GettingStarted/HelmSetup.md
+++ b/versioned_docs/version-v0.14/GettingStarted/HelmSetup.md
@@ -2,7 +2,7 @@
 title: "Install via Helm"
 description: >
   The steps to install Apache DevLake via Helm for Kubernetes
-sidebar_position: 3
+sidebar_position: 2
 ---
 
 ## Prerequisites

--- a/versioned_docs/version-v0.14/GettingStarted/KubernetesSetup.md
+++ b/versioned_docs/version-v0.14/GettingStarted/KubernetesSetup.md
@@ -2,8 +2,14 @@
 title: "Install via Kubernetes"
 description: >
   The steps to install Apache DevLake via Kubernetes
-sidebar_position: 2
+sidebar_position: 3
 ---
+
+:::caution
+
+We highly recommend the [helm approach](./HelmSetup.md), this page is for Advanced Installation only
+
+:::
 
 We provide a sample [k8s-deploy.yaml](https://github.com/apache/incubator-devlake/blob/main/deployment/k8s/k8s-deploy.yaml) to help deploy DevLake to Kubernetes
 


### PR DESCRIPTION

# Summary
Recommending helm installation over k8s and added caution message that k8s is only for advanced use cases

### Does this close any open issues?
Closes [#3954](https://github.com/apache/incubator-devlake/issues/3954#issuecomment-1373112072) in the incubator-devlake repo

### Screenshots
1. Fixed order i.e. helm over k8s
<img width="297" alt="image" src="https://user-images.githubusercontent.com/73993394/211564376-ecb7935a-a489-4e67-b561-4bc48c89042e.png">

2. Added caution message
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/73993394/211564399-f5efc6e2-152d-41be-9d20-fbe006fa8f94.png">
