### PR TITLE
docs: add error codes to troubleshooting docs

### DIFF
--- a/versioned_docs/version-v0.14/Troubleshooting.md
+++ b/versioned_docs/version-v0.14/Troubleshooting.md
@@ -1,8 +1,8 @@
 ---
-title: "Configuration and Blueprint Troubleshooting"
-sidebar_position: 2
+title: "Troubleshooting"
+sidebar_position: 10
 description: >
-  Debug errors found in Config UI or during data collection.
+  DevLake Troubleshooting
 ---
 
 ### Common Error Code while collecting/processing data


### PR DESCRIPTION
### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have `npm run build` and `npm run serve` locally before submitting this PR
- [x] I have read through the [Contributing](https://devlake.apache.org/community/) Documentation

# Summary
- Add the common error codes to the troubleshooting doc in main and v0.14 docs
- Add GitExtractor panic error to the troubleshooting doc in main and v0.14 docs

<!--
Thanks for submitting a PR! We appreciate you spending the time to work on these changes. Please fill out as many sections below as possible.
-->

### Does this close any open issues?
Closes #398 

### Screenshots
![image](https://user-images.githubusercontent.com/14050754/212933649-033c6804-a6e4-4079-8574-bef3af61cec4.png)
