### PR TITLE
Update KeyConcepts.md

### DIFF
--- a/docs/DataModels/ToolLayerSchema.md
+++ b/docs/DataModels/ToolLayerSchema.md
@@ -19,7 +19,7 @@ As a user, you can check tool data tables to verify data quality if you have con
 
 ## Data Models
 
-Tool layer tables start with a prefix `_tool_`. Each plugin contains multiple tool data tables, the naming convension of these tables is `_raw_{plugin}_{entity}`. For instance,
+Tool layer tables start with a prefix `_tool_`. Each plugin contains multiple tool data tables, the naming convension of these tables is `_tool_{plugin}_{entity}`. For instance,
 - _tool_jira_issues
 - _tool_jira_boards
 - _tool_jira_board_issues`

--- a/docs/Overview/KeyConcepts.md
+++ b/docs/Overview/KeyConcepts.md
@@ -105,6 +105,6 @@ Notice: **You can manually orchestrate the pipeline in Configuration UI Advanced
 ### Subtasks
 **A subtask is the minimal work unit in a pipeline that performs in any of the four roles: `Collectors`, `Extractors`, `Converters` and `Enrichers`.** Subtasks are executed in sequential orders.
 - `Collectors`: Collect raw data from data sources, normally via DevLake API and stored into `raw data table`
-- `Extractors`: Extract data from `raw data table` to `domain layer tables`
+- `Extractors`: Extract data from `raw data tables` to `tool layer tables`
 - `Converters`: Convert data from `tool layer tables` into `domain layer tables`
 - `Enrichers`: Enrich data from one domain to other domains. For instance, the Fourier Transformation can examine `issue_changelog` to show time distribution of an issue on every assignee.

--- a/versioned_docs/version-v0.15/DataModels/ToolLayerSchema.md
+++ b/versioned_docs/version-v0.15/DataModels/ToolLayerSchema.md
@@ -19,7 +19,7 @@ As a user, you can check tool data tables to verify data quality if you have con
 
 ## Data Models
 
-Tool layer tables start with a prefix `_tool_`. Each plugin contains multiple tool data tables, the naming convension of these tables is `_raw_{plugin}_{entity}`. For instance,
+Tool layer tables start with a prefix `_tool_`. Each plugin contains multiple tool data tables, the naming convension of these tables is `_tool_{plugin}_{entity}`. For instance,
 - _tool_jira_issues
 - _tool_jira_boards
 - _tool_jira_board_issues`

--- a/versioned_docs/version-v0.15/Overview/KeyConcepts.md
+++ b/versioned_docs/version-v0.15/Overview/KeyConcepts.md
@@ -105,6 +105,6 @@ Notice: **You can manually orchestrate the pipeline in Configuration UI Advanced
 ### Subtasks
 **A subtask is the minimal work unit in a pipeline that performs in any of the four roles: `Collectors`, `Extractors`, `Converters` and `Enrichers`.** Subtasks are executed in sequential orders.
 - `Collectors`: Collect raw data from data sources, normally via DevLake API and stored into `raw data table`
-- `Extractors`: Extract data from `raw data table` to `tool layer tables`
+- `Extractors`: Extract data from `raw data tables` to `tool layer tables`
 - `Converters`: Convert data from `tool layer tables` into `domain layer tables`
 - `Enrichers`: Enrich data from one domain to other domains. For instance, the Fourier Transformation can examine `issue_changelog` to show time distribution of an issue on every assignee.

--- a/versioned_docs/version-v0.15/Overview/KeyConcepts.md
+++ b/versioned_docs/version-v0.15/Overview/KeyConcepts.md
@@ -105,6 +105,6 @@ Notice: **You can manually orchestrate the pipeline in Configuration UI Advanced
 ### Subtasks
 **A subtask is the minimal work unit in a pipeline that performs in any of the four roles: `Collectors`, `Extractors`, `Converters` and `Enrichers`.** Subtasks are executed in sequential orders.
 - `Collectors`: Collect raw data from data sources, normally via DevLake API and stored into `raw data table`
-- `Extractors`: Extract data from `raw data table` to `domain layer tables`
+- `Extractors`: Extract data from `raw data table` to `tool layer tables`
 - `Converters`: Convert data from `tool layer tables` into `domain layer tables`
 - `Enrichers`: Enrich data from one domain to other domains. For instance, the Fourier Transformation can examine `issue_changelog` to show time distribution of an issue on every assignee.


### PR DESCRIPTION
According to offical architecture document, the data flow should be raw data->tool layer tables->domain layer tables.

As a result, roles in  pipelines shoue be collectors->extractors->converters->enrichers.

Among them, the function of extractors should be 
- extract data from `raw data table` to **`tool layer tables`**
rather than 
- extract data from `raw data table` to **`domain layer tables`**.