### PR TITLE
docs: update helm latest version to 0.15.1-beta5

### DIFF
--- a/docs/GettingStarted/HelmSetup.md
+++ b/docs/GettingStarted/HelmSetup.md
@@ -22,7 +22,7 @@ To install the chart with release name `devlake`:
 ```shell
 helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
 helm repo update
-helm install devlake devlake/devlake --version=0.15.0-rc5
+helm install devlake devlake/devlake --version=0.15.1-beta5
 ```
 
 And visit your devlake from the node port (32001 by default).
@@ -47,7 +47,7 @@ grafana by url `http://YOUR-NODE-IP:30091`
 
 ```shell
 helm repo update
-helm upgrade --install devlake devlake/devlake --version=0.15.0-rc5
+helm upgrade --install devlake devlake/devlake --version=0.15.1-beta5
 ```
 
 ### Uninstall

--- a/versioned_docs/version-v0.15/GettingStarted/HelmSetup.md
+++ b/versioned_docs/version-v0.15/GettingStarted/HelmSetup.md
@@ -22,7 +22,7 @@ To install the chart with release name `devlake`:
 ```shell
 helm repo add devlake https://apache.github.io/incubator-devlake-helm-chart
 helm repo update
-helm install devlake devlake/devlake --version=0.15.0-rc5
+helm install devlake devlake/devlake --version=0.15.1-beta5
 ```
 
 And visit your devlake from the node port (32001 by default).
@@ -47,7 +47,7 @@ grafana by url `http://YOUR-NODE-IP:30091`
 
 ```shell
 helm repo update
-helm upgrade --install devlake devlake/devlake --version=0.15.0-rc5
+helm upgrade --install devlake devlake/devlake --version=0.15.1-beta5
 ```
 
 ### Uninstall


### PR DESCRIPTION
Replace `0.15.0-rc5` with `0.15.1-beta5` in both the latest doc and v0.15 doc.
