### PR TITLE
fix: fix gitlab docs

### DIFF
--- a/docs/Configuration/GitLab.md
+++ b/docs/Configuration/GitLab.md
@@ -28,12 +28,10 @@ GitLab personal access tokens are required to add a connection. Learn about [how
 
 ###### GitLab personal access tokens
 
-The following permissions are required to collect data from repositories:
+At least one of the following permissions is required to collect data from repositories:
 
 - `api`
 - `read_api`
-- `read_user`
-- `read_repository`
 
 You also have to double-check your GitLab user permission settings.
 

--- a/versioned_docs/version-v0.15/UserManuals/ConfigUI/GitLab.md
+++ b/versioned_docs/version-v0.15/UserManuals/ConfigUI/GitLab.md
@@ -28,12 +28,10 @@ GitLab personal access tokens are required to add a connection. Learn about [how
 
 ###### GitLab personal access tokens
 
-The following permissions are required to collect data from repositories:
+At least one of the following permissions is required to collect data from repositories:
 
 - `api`
 - `read_api`
-- `read_user`
-- `read_repository`
 
 You also have to double-check your GitLab user permission settings.
 

--- a/versioned_docs/version-v0.16/Configuration/GitLab.md
+++ b/versioned_docs/version-v0.16/Configuration/GitLab.md
@@ -28,12 +28,10 @@ GitLab personal access tokens are required to add a connection. Learn about [how
 
 ###### GitLab personal access tokens
 
-The following permissions are required to collect data from repositories:
+At least one of the following permissions is required to collect data from repositories:
 
 - `api`
 - `read_api`
-- `read_user`
-- `read_repository`
 
 You also have to double-check your GitLab user permission settings.
 


### PR DESCRIPTION
# Summary
Fix gitlab person access tokens documents.
The token permission only required `api` or `read_api` is enough.

### Does this close any open issues?
Closes [#4784](https://github.com/apache/incubator-devlake/issues/4784)
