### PR TITLE
ci(link): link check support change of doc sturcture

### DIFF
--- a/.github/workflows/pr_ci.yaml
+++ b/.github/workflows/pr_ci.yaml
@@ -15,10 +15,22 @@ jobs:
         uses: actions/setup-node@main
         with:
           node-version: 17.8.x
+      - name: Replace base url
+        run: |
+          # replace base url to localhost to support change of doc structure
+          sed -i 's#https://devlake.apache.org#http://local.devlake.apache.org#g' docusaurus.config.js
+      - name: Edit hosts
+        run: |
+          # why we need this:
+          # lychee will ignore links to localhost, so we need to add a new domain to avoid this
+          echo "127.0.0.1 local.devlake.apache.org" | sudo tee -a /etc/hosts
       - name: Build Docusaurus website
         run: |
           npm install
           npm run build
+      - name: Install http-server
+        run: |
+          sudo npm install -g http-server
       - name: Install lychee
         env:
           LYCHEEVERSION: 0.12.0
@@ -35,6 +47,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
+          # to run a local server, so that lychee can check links on it rather than on devlake.apache.org
+          sudo http-server ./build -s -p 80 -a 0.0.0.0 &
+          # wait for http-server to start
+          npm install wait-on
+          npx wait-on http://local.devlake.apache.org -t 60000
+          
           # For parameter description, see https://github.com/lycheeverse/lychee#commandline-parameters
           # -E, --exclude-all-private    Exclude all private IPs from checking.
           # -i, --insecure               Proceed for server connections considered insecure (invalid TLS)


### PR DESCRIPTION
### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have `npm run build` and `npm run serve` locally before submitting this PR
- [x] I have read through the [Contributing](https://devlake.apache.org/community/) Documentation

# Summary

To fix #509 

* use `localhost` as website base url and run a local http-server
* so that the request to the new doc can be handled in `http://localhost/....` rather than `devlake.apache.org`

（There are some details, such as hosts, that can be found in the code changes. Please refer to them for further information.）

### Does this close any open issues?
Closes #509

### Other Information

You can see this PR in my fork repo, which based on the code of #504 to show that new link check CI works well.

https://github.com/aFlyBird0/incubator-devlake-website/pull/1
