### PR TITLE
docs: back up dashboards before upgrade

### DIFF
--- a/docs/GettingStarted/DockerComposeSetup.md
+++ b/docs/GettingStarted/DockerComposeSetup.md
@@ -27,9 +27,11 @@ sidebar_position: 1
 
 ## Upgrade to a newer version
 
+Please note: **Back up your Grafana dashboards** before upgrade if you have modified/customized any dashboards. You can re-import these dashboards to Grafana after the upgrade.
+
 1. Run `docker-compose down` to stop services;
 2. Open file "docker-compose.yml". Change the image tags of "grafana", "devlake" and "config-ui" to the new version, and save;
-3. Run `docker-compose up -d` start DevLake services.
+3. Run `docker-compose up -d` to start DevLake services.
 
 Please check the [upgrade doc](Upgrade.md) for more information.
 

--- a/docs/GettingStarted/HelmSetup.md
+++ b/docs/GettingStarted/HelmSetup.md
@@ -43,7 +43,9 @@ Then you can visit:
 Config UI URL `http://YOUR-NODE-IP:30090`
 Grafana URL `http://YOUR-NODE-IP:30091`
 
-### Update
+### Upgrade
+
+Please note: **Back up your Grafana dashboards** before upgrade if you have modified/customized any dashboards. You can re-import these dashboards to Grafana after the upgrade.
 
 ```shell
 helm repo update

--- a/versioned_docs/version-v0.16/GettingStarted/DockerComposeSetup.md
+++ b/versioned_docs/version-v0.16/GettingStarted/DockerComposeSetup.md
@@ -12,8 +12,6 @@ sidebar_position: 1
 
 ## Launch DevLake
 
-Commands written `like this` are to be run in your terminal or pasted in the web browser.
-
 1. Download `docker-compose.yml` and `env.example` from the [latest release](https://github.com/apache/incubator-devlake/releases/tag/v0.16.1-beta1) into a folder.
 2. Rename `env.example` to `.env`. For Mac/Linux users, please run `mv env.example .env` in the terminal. This file contains the environment variables that the Devlake server will use. Additional ones can be found in the compose file(s).
 3. Run `docker-compose up -d` if the version of Docker Desktop is too low to use `docker compose up -d`.
@@ -29,9 +27,11 @@ Commands written `like this` are to be run in your terminal or pasted in the web
 
 ## Upgrade to a newer version
 
+Please note: **Back up your Grafana dashboards** before upgrade if you have modified/customized any dashboards. You can re-import these dashboards to Grafana after the upgrade.
+
 1. Run `docker-compose down` to stop services;
 2. Open file "docker-compose.yml". Change the image tags of "grafana", "devlake" and "config-ui" to the new version, and save;
-3. Run `docker-compose up -d` start DevLake services.
+3. Run `docker-compose up -d` to start DevLake services.
 
 Please check the [upgrade doc](Upgrade.md) for more information.
 

--- a/versioned_docs/version-v0.16/GettingStarted/HelmSetup.md
+++ b/versioned_docs/version-v0.16/GettingStarted/HelmSetup.md
@@ -43,7 +43,9 @@ Then you can visit:
 Config UI URL `http://YOUR-NODE-IP:30090`
 Grafana URL `http://YOUR-NODE-IP:30091`
 
-### Update
+### Upgrade
+
+Please note: **Back up your Grafana dashboards** before upgrade if you have modified/customized any dashboards. You can re-import these dashboards to Grafana after the upgrade.
 
 ```shell
 helm repo update

--- a/versioned_docs/version-v0.17/GettingStarted/DockerComposeSetup.md
+++ b/versioned_docs/version-v0.17/GettingStarted/DockerComposeSetup.md
@@ -12,7 +12,7 @@ sidebar_position: 1
 
 ## Launch DevLake
 
-1. Download `docker-compose.yml` and `env.example` from the [latest release](https://github.com/apache/incubator-devlake/releases/tag/v0.17.0-beta3) into a folder.
+1. Download `docker-compose.yml` and `env.example` from the [latest release](https://github.com/apache/incubator-devlake/releases/tag/v0.17.0-beta4) into a folder.
 2. Rename `env.example` to `.env`. For Mac/Linux users, please run `mv env.example .env` in the terminal. This file contains the environment variables that the Devlake server will use. Additional ones can be found in the compose file(s).
 3. Run `docker-compose up -d` if the version of Docker Desktop is too low to use `docker compose up -d`.
 
@@ -27,9 +27,11 @@ sidebar_position: 1
 
 ## Upgrade to a newer version
 
+Please note: **Back up your Grafana dashboards** before upgrade if you have modified/customized any dashboards. You can re-import these dashboards to Grafana after the upgrade.
+
 1. Run `docker-compose down` to stop services;
 2. Open file "docker-compose.yml". Change the image tags of "grafana", "devlake" and "config-ui" to the new version, and save;
-3. Run `docker-compose up -d` start DevLake services.
+3. Run `docker-compose up -d` to start DevLake services.
 
 Please check the [upgrade doc](Upgrade.md) for more information.
 

--- a/versioned_docs/version-v0.17/GettingStarted/HelmSetup.md
+++ b/versioned_docs/version-v0.17/GettingStarted/HelmSetup.md
@@ -43,11 +43,13 @@ Then you can visit:
 Config UI URL `http://YOUR-NODE-IP:30090`
 Grafana URL `http://YOUR-NODE-IP:30091`
 
-### Update
+### Upgrade
+
+Please note: **Back up your Grafana dashboards** before upgrade if you have modified/customized any dashboards. You can re-import these dashboards to Grafana after the upgrade.
 
 ```shell
 helm repo update
-helm upgrade --install devlake devlake/devlake --version=0.17.0-beta3
+helm upgrade --install devlake devlake/devlake --version=0.17.0-beta4
 ```
 
 Please check the [upgrade doc](Upgrade.md) for more information.


### PR DESCRIPTION
### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have `npm run build` and `npm run serve` locally before submitting this PR
- [x] I have read through the [Contributing](https://devlake.apache.org/community/) Documentation

# Summary
Tell the user to back up dashboards before the upgrade.
<!--
Thanks for submitting a PR! We appreciate you spending the time to work on these changes. Please fill out as many sections below as possible.
-->


### Screenshots
![image](https://user-images.githubusercontent.com/14050754/236834385-b21c752b-24a8-47a1-9e81-3f62651737c1.png)

