### PR TITLE
fix: HEAD method is not working for some websites

### DIFF
--- a/.github/workflows/link-schedule.yaml
+++ b/.github/workflows/link-schedule.yaml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_WORKFLOW_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true"
 
           if ! lychee --output ${OUTPUT_FILE} \
-            -E -i -n -t 5 --max-concurrency 64 -a 429,401,403 -m 10 -f markdown -s http -s https -X HEAD \
+            -E -i -n -t 5 --max-concurrency 64 -a 429,401,403 -m 10 -f markdown -s http -s https \
             '**/*.md'
           then
             echo "" >> "${OUTPUT_FILE}" # add a new line

--- a/.github/workflows/pr_ci.yaml
+++ b/.github/workflows/pr_ci.yaml
@@ -32,7 +32,7 @@ jobs:
           git diff --name-only ${{ github.event.pull_request.base.sha }}... | grep -P '\.md$' > modified_files  || true
           if [ -s modified_files ]; then
             # run lychee
-            cat modified_files | xargs -d '\n' -- lychee -E -i -n -t 45 --max-concurrency 64 -a 409,401,403 -m 10 -s http -s https -X HEAD -- 
+            cat modified_files | xargs -d '\n' -- lychee -E -i -n -t 45 --max-concurrency 64 -a 409,401,403 -m 10 -s http -s https -- 
           fi
       - name: Use Node.js 17.8.x
         uses: actions/setup-node@main


### PR DESCRIPTION
  e.g. https://open.feishu.cn/document/ukTMukTMukTM/ukDNz4SO0MjL5QzM/auth-v3/auth/tenant_access_token_internal

# Summary

To fix errors from: https://github.com/apache/incubator-devlake-website/actions/runs/5629918621/job/15276953807?pr=592

URL like https://open.feishu.cn/document/ukTMukTMukTM/ukDNz4SO0MjL5QzM/auth-v3/auth/tenant_access_token_internal actually ok when requesting using the GET method and 404 when using HEAD or other newer HTTP method.

# Tested

![image](https://github.com/apache/incubator-devlake-website/assets/61080/3dec7e03-f2b2-4365-9d60-c9328253abf4)
