### PR TITLE
Fixes ambiguity on environment key values

### DIFF
--- a/docs/Plugins/webhook.md
+++ b/docs/Plugins/webhook.md
@@ -54,7 +54,7 @@ You can copy the generated deployment curl commands to your CI/CD script to post
 |     Key     | Required | Notes                                                                                                                                                                           |
 | :---------: | :------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | pipeline_id |  ✖️ No   | related Domain Layer `cicd_pipelines.id`                                                                                                                                         |
-| environment |  ✖️ No   | the environment this deployment happens. For example, `PRODUCTION` `STAGING` `TESTING` `DEVELOPMENT`. <br/>The default value is `PRODUCTION`                  |
+| environment |  ✖️ No   | the environment this deployment happens, one of the values: `PRODUCTION`, `STAGING`, `TESTING`, `DEVELOPMENT`. <br/>The default value is `PRODUCTION`.                  |
 |  repo_url   |  ✔️ Yes  | the repo URL of the deployment commit<br />If there is a row in the domain layer table `repos` where `repos.url` equals `repo_url`, the `repoId` will be filled with `repos.id`. |
 |   repo_id   |  ✖️ No   | related Domain Layer `repos.id` <br/> No default value.                                                                                                                          |
 |    name     |  ✖️ No   | deployment name. The default value is "deployment for `request.commit_sha`"                                                                                   |
@@ -64,7 +64,7 @@ You can copy the generated deployment curl commands to your CI/CD script to post
 | create_time |  ✖️ No   | Time. Eg. 2020-01-01T12:00:00+00:00<br/> No default value.                                                                                                                       |
 | start_time  |  ✔️ Yes  | Time. Eg. 2020-01-01T12:00:00+00:00<br/> No default value.                                                                                                    |
 |  end_time   |  ✖️ No   | Time. Eg. 2020-01-01T12:00:00+00:00<br/> The default value is the time when DevLake receives the POST request.                                                                   |
-|   result    |  ✖️ No   | deployment result, one of the values : `SUCCESS`, `FAILURE`, `ABORT`, `MANUAL`, <br/> The default value is `SUCCESS`.                                                            |
+|   result    |  ✖️ No   | deployment result, one of the values: `SUCCESS`, `FAILURE`, `ABORT`, `MANUAL`. <br/> The default value is `SUCCESS`.                                                            |
 | deploymentCommits[]    |  ✖️ yes  | Allow deployment webhook to push deployments to multiple repos in one request, includes repo_url,commit_sha,commit_msg,name,ref_name    |
 
 


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a PR! We appreciate you spending the time to work on these changes. Please fill out as many sections below as possible.
-->

### Does this close any open issues?
No, I didn't see much point opening an issue, it's a very small change.

### Screenshots
<img width="1021" alt="Screenshot 2024-02-08 at 14 46 25" src="https://github.com/apache/incubator-devlake-website/assets/297653/4cbcea38-38b0-4126-8613-3670a44f92ee">


### Other Information
Fixes ambiguity in the documentation for the 'environment' key - the original language implies that other keys can be used (as those given are examples, it should be valid to use `FOOBAR`, for example).

This change specifies that the 'environment' key must be one of those listed, and align with the 'result' key format (and clean up the 'result' key format a little too).
