### PR TITLE
Update Incorrect Plugin Link for DBT plugin - DevLakeDomainLayerSchem…

### DIFF
--- a/docs/DataModels/DevLakeDomainLayerSchema.md
+++ b/docs/DataModels/DevLakeDomainLayerSchema.md
@@ -60,7 +60,7 @@ Tables that end with WIP are still under development.
 Apache DevLake provides 2 plugins:
 
 - [customize](https://devlake.apache.org/docs/Plugins/customize): to create/delete columns in the domain layer schema with the data extracted from [raw layer tables](https://devlake.apache.org/docs/Overview/Architecture/#dataflow)
-- [dbt](https://devlake.apache.org/docs/Plugins/customize): to transform data based on the domain layer schema and generate new tables
+- [dbt](https://devlake.apache.org/docs/Plugins/dbt): to transform data based on the domain layer schema and generate new tables
 
 <br/>
 


### PR DESCRIPTION
…a.md
I don't have `npm run build` and `npm run serve` locally since I'm fixing a small URL error in the documentation. 

In DevLakeDomainLayerSchema.md, the URL of dbt plugin points to another plugin 'customize'.

### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [No] I have `npm run build` and `npm run serve` locally before submitting this PR
- [Yes] I have read through the [Contributing](https://devlake.apache.org/community/) Documentation

# Summary

<!--
Thanks for submitting a PR! We appreciate you spending the time to work on these changes. Please fill out as many sections below as possible.
-->

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
