### PR TITLE
Attempt to fix CSP to allow RunLLM widget

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -149,7 +149,7 @@ const versions = require('./versions.json');
           },
           {
             name: 'Content-Security-Policy',
-            content: "frame-src 'self' https://www.google.com/recaptcha/;"
+            content: "frame-src 'self' https://www.google.com/recaptcha/ https://www.google.com/;"
           }
       ],
       navbar: {


### PR DESCRIPTION
### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have `npm run build` and `npm run serve` locally before submitting this PR
- [x] I have read through the [Contributing](https://devlake.apache.org/community/) Documentation

# Summary
This PR attempts to fix the CSP issue that's blocking the RunLLM widget from loading. Previously we weren't allowing the parent url https://www.google.com/, which may be the issue.

<!--
Thanks for submitting a PR! We appreciate you spending the time to work on these changes. Please fill out as many sections below as possible.
-->

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
