### PR TITLE
fix(docs): set correct url for closing issues

### DIFF
--- a/docs/Plugins/webhook.md
+++ b/docs/Plugins/webhook.md
@@ -214,7 +214,7 @@ More information about these columns at the [domain layer issues table](/DataMod
 
 #### Register Issues - Close Issues (Optional)
 
-`POST <devlake-host>/api/rest/plugins/webhook/1/issue/:issueId/close`
+`POST <devlake-host>/api/rest/plugins/webhook/connections/1/issue/:issueId/close`
 
 needs to be called when an issue or incident is closed. Replace `:issueId` with specific strings and keep the body empty.
 


### PR DESCRIPTION
### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have `npm run build` and `npm run serve` locally before submitting this PR
- [x] I have read through the [Contributing](https://devlake.apache.org/community/) Documentation

# Summary
Docs showed wrong URL only for closing issues.



### Does this close any open issues?
I havent opened an issue on this

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.

Im unsure if you want to change the files for the versioned API docs as well? 
`/versioned_docs/version-v0.21/Plugins/webhook.md`
`/versioned_docs/version-v1.0/Plugins/webhook.md`
