### PR TITLE
fix(typos): fix typo in references.md

### DIFF
--- a/docs/Overview/References.md
+++ b/docs/Overview/References.md
@@ -9,11 +9,11 @@ For users/developers who wish to interact with the Apache DevLake by using the R
 the Swagger Document would very useful for you. The `devlake` docker image has it packaged, you may access it from:
 If you are using the `devlake` container alone without `config-ui`:
 ```
-http://<DEVLAKE_CONTIANER_HOST>:<PORT>/swagger/index.html
+http://<DEVLAKE_CONTAINER_HOST>:<PORT>/swagger/index.html
 ```
 or
 ```
-http://<CONFIG_UI_CONTIANER_HOST>:<PORT>/api/swagger/index.html
+http://<CONFIG_UI_CONTAINER_HOST>:<PORT>/api/swagger/index.html
 ```
 
 


### PR DESCRIPTION
# Summary
A small typo fix.

### Does this close any open issues?
N/A

### Screenshots
Fix for this typo
<img width="1434" height="629" alt="Screenshot 2025-07-15 at 11 40 34" src="https://github.com/user-attachments/assets/2fcc69d8-19ac-4921-83ea-46b1cad5921a" />

### Other Information
N/A