### PR TITLE
fix(ui): responsive layout for joinCommunity component in smaller screens

### DIFF
--- a/src/components/Sections/JoinCommunity.tsx
+++ b/src/components/Sections/JoinCommunity.tsx
@@ -5,10 +5,10 @@ import Join from "@site/static/img/Homepage/Join.png";
 import { InlineLink } from "./Components";
 
 export function JoinCommunity() {
-  return (<div className="flex align-self-center justify-between xl:relative right-2
+  return (<div className="flex justify-between xl:relative right-2
     my-[72px] rounded-[20px] bg-primary-200 px-5 py-[36px] font-inter xl:mx-auto xl:w-[72vw] xl:max-w-[1300px]
-    sm:w-[87vw] sm:my-6 sm:p-4 mobile:my-4 mobile:p-3 mobile:mt-[80px] sm:mt-[180px]">
-    <div className="w-[600px] pr-3 sm:pr-[0] sm:w-auto">
+    sm:w-[87vw] sm:my-6 sm:p-4 sm:flex-col mobile:my-4 mobile:p-3 mobile:mt-[80px] sm:mt-[180px]">
+    <div className="w-[600px] pr-3 sm:pr-[0] sm:w-auto sm:order-2">
       <div className="text-heading1 mb-3 text-primary-800 font-semibold
         sm:text-heading2">Join the Community</div>
       <div className="text-label18 mb-4 text-neutral-500
@@ -18,6 +18,6 @@ export function JoinCommunity() {
         <InlineLink link="https://devlake.apache.org/community/subscribe">Subscribe to Mailing List</InlineLink>
       </div>
     </div>
-    <img src={Join} alt='' className="w-[216px] h-[200px] sm:mx-auto sm:mb-4" />
+    <img src={Join} alt='' className="w-[216px] h-[200px] sm:mx-auto sm:mb-4 sm:order-1" />
   </div>)
 }


### PR DESCRIPTION
### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have `npm run build` and `npm run serve` locally before submitting this PR
- [x] I have read through the [Contributing](https://devlake.apache.org/community/) Documentation

# Summary

### Problem
- The Join Community component was not responsive on smaller screens and the image was overflowing from the container.

### What Changes
- Fixed the component with tailwind css classes and made it responsive for smaller screens.

### Screenshots

## Before
<img width="300"  alt="Screenshot 2026-01-24 201521" src="https://github.com/user-attachments/assets/00c437a3-7407-48ff-b557-0640cd2712ad" />
<img width="300"  alt="Screenshot 2026-01-24 201535" src="https://github.com/user-attachments/assets/dae29c85-723e-439a-81cb-dd3eb5bb6142" />
<img width="300" alt="Screenshot 2026-01-24 201605" src="https://github.com/user-attachments/assets/f9862963-9f80-402b-b4b7-e577c009ecbd" />

## After
<img width="300"  alt="Screenshot 2026-01-24 211654" src="https://github.com/user-attachments/assets/27b66f91-a0d1-4996-ac1b-a7c5d256cf40" />
<img width="300"  alt="Screenshot 2026-01-24 201543" src="https://github.com/user-attachments/assets/4a3ec3d5-5e15-4acd-9331-df41d15a0fd2" />
<img width="300"  alt="Screenshot 2026-01-24 201613" src="https://github.com/user-attachments/assets/8009ef9e-7a77-4e7e-90bb-ea1443ee43e9" />


