### PR TITLE
docs: add gh-devlake CLI to QuickStart as alternative installation method

### DIFF
--- a/docs/GettingStarted/QuickStart.md
+++ b/docs/GettingStarted/QuickStart.md
@@ -8,7 +8,14 @@ sidebar_position: 1
 The key steps to deploy and utilize Apache DevLake.
 
 ## Step 1. Install DevLake
-Install DevLake using either <a href="DockerComposeSetup">Docker Compose</a> or <a href="HelmSetup">Helm</a>. If you want to upgrade DevLake to a newer version, please refer to the <a href="Upgrade">upgrade manuals</a>.
+Install DevLake using either <a href="DockerComposeSetup">Docker Compose</a>, <a href="HelmSetup">Helm</a>, or the <a href="https://github.com/DevExpGBB/gh-devlake">gh-devlake CLI</a>. If you want to upgrade DevLake to a newer version, please refer to the <a href="Upgrade">upgrade manuals</a>.
+
+**Prefer the terminal?** You can use [gh-devlake](https://github.com/DevExpGBB/gh-devlake), a GitHub CLI extension that deploys, configures, and monitors DevLake entirely from the command line:
+
+```bash
+gh extension install DevExpGBB/gh-devlake
+gh devlake init
+```
 
 ## Step 2. Configure DevLake
 Configure DevLake via the Config UI. Follow the <a href="/docs/Configuration/Tutorial">tutorial</a> for configuration instructions. If you specifically want to configure DORA metrics, please refer to the <a href="/docs/DORA">DORA manuals</a> for detailed instructions.


### PR DESCRIPTION
### Summary

Adds [gh-devlake](https://github.com/DevExpGBB/gh-devlake) as a third installation option in the **Quick Start** guide (Step 1), alongside Docker Compose and Helm.

### What is gh-devlake?

`gh-devlake` is a GitHub CLI extension that automates Apache DevLake deployment, configuration, and monitoring entirely from the terminal. It supports both local Docker and Azure deployments, handles connections to GitHub and GitHub Copilot, and enables DORA metrics computation without requiring the web UI. Support for additional plugins is coming soon.

### Changes

- Updated Step 1 text to include gh-devlake as a third option
- Added a brief "Prefer the terminal?" section with install snippet:
  ```bash
  gh extension install DevExpGBB/gh-devlake
  gh devlake init
  ```

Related: apache/incubator-devlake#8732
Companion PR: apache/incubator-devlake#8733