### PR TITLE
fix: remove the deprecated demo links

### DIFF
--- a/livedemo/DataSources/GitHub.md
+++ b/livedemo/DataSources/GitHub.md
@@ -16,8 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/d/KXWvOFQnz/github?orgId=1&from=now-6M&to=now)**
-
 ![GitHub](./GitHub.png)
 
 <!-- <iframe src="https://grafana-lake.demo.devlake.io/d/KXWvOFQnz/github?orgId=1&from=now-6M&to=now" width="135%" height="3000px"></iframe> -->

--- a/livedemo/DataSources/GitLab.md
+++ b/livedemo/DataSources/GitLab.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/grafana/d/msSjEq97z/gitlab?orgId=1)**
 
 ![GitLab](./GitLab.png)
 

--- a/livedemo/DataSources/Jenkins.md
+++ b/livedemo/DataSources/Jenkins.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/d/W8AiDFQnk/jenkins?orgId=1&from=now-6M&to=now)**
 
 ![Jenkins](./Jenkins.png)
 

--- a/livedemo/DataSources/Jira.md
+++ b/livedemo/DataSources/Jira.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/grafana/d/F5vqBQl7z/jira?orgId=1&from=now-6M&to=now)**
 
 ![Jira](./Jira.png)
 

--- a/livedemo/DataSources/SonarQube.md
+++ b/livedemo/DataSources/SonarQube.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/grafana/d/WA0qbuJ4k/sonarqube?orgId=1&from=now-6M&to=now)**
 
 ![SonarQube](./SonarQube.png)
 

--- a/livedemo/EngineeringLeads/DORA.md
+++ b/livedemo/EngineeringLeads/DORA.md
@@ -25,7 +25,6 @@ To set up your own DORA metrics dashboard, you can checkout our detailed [DORA u
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/grafana/d/qNo8_0M4z/dora?orgId=1&from=now-6M&to=now)**
 
 ![DORA](./DORA.png)
 

--- a/livedemo/EngineeringLeads/EngineeringOverview.md
+++ b/livedemo/EngineeringLeads/EngineeringOverview.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/grafana/d/ZF6abXX7z/engineering-overview?orgId=1)**
 
 ![EngineeringOverview](./EngineeringOverview.png)
 

--- a/livedemo/EngineeringLeads/EngineeringThroughputAndCycleTime.md
+++ b/livedemo/EngineeringLeads/EngineeringThroughputAndCycleTime.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/grafana/d/Jaaimc67k/engineering-throughput-and-cycle-time?orgId=1)**
 
 ![EngineeringThroughputAndCycleTime](./EngineeringThroughputAndCycleTime.png)
 

--- a/livedemo/EngineeringLeads/EngineeringThroughputAndCycleTimeTeamView.md
+++ b/livedemo/EngineeringLeads/EngineeringThroughputAndCycleTimeTeamView.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/grafana/d/nJ1ijje7k/engineering-throughput-and-cycle-time-team-view?orgId=1)**
 
 ![EngineeringThroughputAndCycleTimeTeamView](./EngineeringThroughputAndCycleTimeTeamView.png)
 

--- a/livedemo/EngineeringLeads/GitextractorMetricsDashboard.md
+++ b/livedemo/EngineeringLeads/GitextractorMetricsDashboard.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/grafana/d/KxUh7IG4z/component-and-file-level-metrics?orgId=1)**
 
 ![GitextractorMetricsDashboard](./GitextractorMetricsDashboard.png)
 

--- a/livedemo/EngineeringLeads/WeeklyBugRetro.md
+++ b/livedemo/EngineeringLeads/WeeklyBugRetro.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/d/-5EKA5w7k/weekly-bug-retro?orgId=1&from=now-6M&to=now)**
 
 ![WeeklyBugRetro](./WeeklyBugRetro.png)
 

--- a/livedemo/OSSMaintainers/CommunityExperience.md
+++ b/livedemo/OSSMaintainers/CommunityExperience.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/grafana/d/bwsP5Nz4z/community-experience?orgId=1&from=now-6M&to=now)**
 
 ![CommunityExperience](./CommunityExperience.png)
 

--- a/livedemo/OSSMaintainers/WeeklyCommunityRetro.md
+++ b/livedemo/OSSMaintainers/WeeklyCommunityRetro.md
@@ -16,7 +16,6 @@ description: >
   </h5>
 </div>
 
-**View live metrics on [🔗 Grafana](https://grafana-lake.demo.devlake.io/grafana/d/VTr6Y_q7z/weekly-community-retro?orgId=1&from=now-6M&to=now)**
 
 ![WeeklyCommunityRetro](./WeeklyCommunityRetro.png)
 


### PR DESCRIPTION
### ⚠️ &nbsp;&nbsp;Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have `npm run build` and `npm run serve` locally before submitting this PR
- [x] I have read through the [Contributing](https://devlake.apache.org/community/) Documentation

# Summary
Remove the links to the demo instance since the instance has been down.

<!--
Thanks for submitting a PR! We appreciate you spending the time to work on these changes. Please fill out as many sections below as possible.
-->

### Does this close any open issues?
Closes https://github.com/apache/incubator-devlake-website/issues/824

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
