### PR TITLE
docs: clarify CircleCI Personal API token setup

### DIFF
--- a/docs/Configuration/CircleCI.md
+++ b/docs/Configuration/CircleCI.md
@@ -23,11 +23,10 @@ For CircleCI, you do not need to enter the REST API endpoint URL, which is alway
 
 #### Token
 
-Learn about [Managing API Tokens](https://circleci.com/docs/managing-api-tokens/).
+Create a [CircleCI Personal API Token](https://circleci.com/docs/managing-api-tokens/#create-a-personal-api-token) for DevLake.
 
-Tokens you have generated that can be used to access the CircleCI API. Apps using these tokens can act as you and have full read- and write-permissions!
-There are two types of API token(Personal and Project) you can create within CircleCI.
-
+Use a token from a CircleCI user who can access the organization and projects you want to collect.
+For SSO-enabled organizations, see CircleCI's [Personal API tokens with SSO](https://circleci.com/docs/guides/permissions-authentication/sso-overview/#personal-api-tokens-with-sso).
 
 #### Proxy URL (Optional)
 
@@ -51,6 +50,8 @@ Click `Test Connection`, if the connection is successful, click `Save Connection
 #### Projects
 
 Select the CircleCI projects to collect.
+
+DevLake can only detect projects that you follow in CircleCI.
 
 ### Step 1.3 - Adding Scope Config (Optional)
 Scope config includes two sets of configurations:


### PR DESCRIPTION
# Summary
The DevLake CircleCI connector uses CircleCI API v2 endpoints for connection checks and data collection. 
However, CircleCI's official documentation states that Project API Tokens are not supported for API v2.

https://circleci.com/docs/api/v1/#get-authenticated
> We recommend using personal API tokens at this time because project API tokens are not supported for API v2.

Because the current wording could be interpreted as saying that Project API Tokens can also be used with DevLake,
this PR updates the CircleCI configuration docs to make it clear that DevLake expects a Personal API Token.


### Does this close any open issues?

No related open issue found.

### Screenshots

N/A

### Other Information
- DevLake's CircleCI connector uses CircleCI API v2 endpoints, including:
  - `/v2/me`
  - `/v2/me/collaborations`
  - `/v2/project/{slug}`
  - `/v2/project/{slug}/pipeline`
  - `/v2/pipeline/{id}/workflow`
  - `/v2/workflow/{id}`
  - `/v2/workflow/{id}/job`

